### PR TITLE
Added Karate for HTTP integration tests and mocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 /build/
+/target/
 !gradle/wrapper/gradle-wrapper.jar
 
 ### STS ###

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.DS_Store
 .gradle
+karate.log
 /build/
 /target/
 !gradle/wrapper/gradle-wrapper.jar

--- a/build.gradle
+++ b/build.gradle
@@ -55,9 +55,9 @@ dependencies {
 	testCompile('au.com.dius:pact-jvm-consumer-junit_2.12:3.5.5')
 	testCompile('au.com.dius:pact-jvm-provider-spring_2.12:3.5.5')
 	testCompile('io.github.bonigarcia:webdrivermanager:2.1.0')
-    testCompile('com.intuit.karate:karate-junit4:0.7.0')
-    testCompile('com.intuit.karate:karate-apache:0.7.0')
-    testCompile('com.intuit.karate:karate-apache:0.7.0')
+    testCompile('com.intuit.karate:karate-junit4:0.7.0.1')
+    testCompile('com.intuit.karate:karate-mock-servlet:0.7.0.1')
+    testCompile('com.intuit.karate:karate-netty:0.7.0.1')
     testCompile('ch.qos.logback:logback-classic:1.2.3')
     testCompile('ch.qos.logback:logback-core:1.2.3')
     

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,15 @@ repositories {
 	mavenCentral()
 }
 
+sourceSets {
+    test {
+        resources {
+            srcDir file('src/test/java')
+            exclude '**/*.java'
+        }
+    }
+}
+
 dependencies {
 	compile('org.springframework.boot:spring-boot-starter')
 	compile('org.springframework.boot:spring-boot-starter-web') {
@@ -46,4 +55,10 @@ dependencies {
 	testCompile('au.com.dius:pact-jvm-consumer-junit_2.12:3.5.5')
 	testCompile('au.com.dius:pact-jvm-provider-spring_2.12:3.5.5')
 	testCompile('io.github.bonigarcia:webdrivermanager:2.1.0')
+    testCompile('com.intuit.karate:karate-junit4:0.7.0')
+    testCompile('com.intuit.karate:karate-apache:0.7.0')
+    testCompile('com.intuit.karate:karate-apache:0.7.0')
+    testCompile('ch.qos.logback:logback-classic:1.2.3')
+    testCompile('ch.qos.logback:logback-core:1.2.3')
+    
 }

--- a/src/test/java/example/ExampleControllerAPIKarateTest.java
+++ b/src/test/java/example/ExampleControllerAPIKarateTest.java
@@ -1,0 +1,50 @@
+package example;
+
+import com.intuit.karate.http.HttpRequestBuilder;
+import com.intuit.karate.junit4.Karate;
+import com.intuit.karate.mock.servlet.MockHttpClient;
+import cucumber.api.CucumberOptions;
+import javax.servlet.Servlet;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+
+@RunWith(Karate.class)
+@CucumberOptions(features = "classpath:example/example-api.feature")
+public class ExampleControllerAPIKarateTest {
+    
+    @BeforeClass
+    public static void beforeClass() {
+        System.setProperty("karate.env", "mock-servlet");
+    }
+    
+    public static MockHttpClient getMock() {
+        return new MockHttpClient() {
+            ServletContext servletContext = new MockServletContext();
+            @Override
+            protected Servlet getServlet(HttpRequestBuilder hrb) {
+                AnnotationConfigWebApplicationContext context = new AnnotationConfigWebApplicationContext();
+                context.register(ExampleControllerConfig.class);
+                context.setServletContext(servletContext);
+                DispatcherServlet servlet = new DispatcherServlet(context);
+                ServletConfig servletConfig = new MockServletConfig();
+                try {
+                    servlet.init(servletConfig);
+                    return servlet;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            @Override
+            protected ServletContext getServletContext() {
+                return servletContext;
+            }
+        };        
+    }
+
+}

--- a/src/test/java/example/ExampleControllerConfig.java
+++ b/src/test/java/example/ExampleControllerConfig.java
@@ -1,0 +1,29 @@
+package example;
+
+import example.person.Person;
+import example.person.PersonRepository;
+import example.weather.WeatherClient;
+import example.weather.WeatherResponse;
+import java.util.Optional;
+import static org.mockito.BDDMockito.given;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import static org.mockito.Mockito.*;
+
+@Configuration
+@EnableAutoConfiguration
+public class ExampleControllerConfig {
+
+    @Bean
+    public ExampleController exampleController() {
+        PersonRepository personRepository = mock(PersonRepository.class);
+        Person peter = new Person("Peter", "Pan");
+        given(personRepository.findByLastName("Pan")).willReturn(Optional.of(peter));
+        WeatherClient weatherClient = mock(WeatherClient.class);
+        WeatherResponse weatherResponse = new WeatherResponse("Hamburg, 8°C raining");
+        given(weatherClient.fetchWeather()).willReturn(Optional.of(weatherResponse));
+        return new ExampleController(personRepository, weatherClient);
+    }
+
+}

--- a/src/test/java/example/HelloE2ERestKarateTest.java
+++ b/src/test/java/example/HelloE2ERestKarateTest.java
@@ -1,0 +1,33 @@
+package example;
+
+import com.intuit.karate.junit4.Karate;
+import example.person.Person;
+import example.person.PersonRepository;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+
+@RunWith(Karate.class)
+public class HelloE2ERestKarateTest {
+    
+    private static PersonRepository personRepository;
+    
+    @BeforeClass
+    public static void beforeClass() {
+        ConfigurableApplicationContext context = SpringApplication.run(ExampleApplication.class, new String[]{"--server.port=0"});
+        personRepository = context.getBean(PersonRepository.class);
+        String port = context.getEnvironment().getProperty("local.server.port");
+        System.setProperty("karate.server.port", port);
+        Person peter = new Person("Peter", "Pan");
+        personRepository.save(peter);        
+    }
+    
+    
+    @AfterClass
+    public static void afterClass() {
+        personRepository.deleteAll();
+    }
+        
+}

--- a/src/test/java/example/HelloE2ERestKarateTest.java
+++ b/src/test/java/example/HelloE2ERestKarateTest.java
@@ -1,6 +1,7 @@
 package example;
 
 import com.intuit.karate.junit4.Karate;
+import cucumber.api.CucumberOptions;
 import example.person.Person;
 import example.person.PersonRepository;
 import org.junit.AfterClass;
@@ -10,6 +11,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
 
 @RunWith(Karate.class)
+@CucumberOptions(features = "classpath:example/example-api.feature")
 public class HelloE2ERestKarateTest {
     
     private static PersonRepository personRepository;
@@ -19,12 +21,12 @@ public class HelloE2ERestKarateTest {
         ConfigurableApplicationContext context = SpringApplication.run(ExampleApplication.class, new String[]{"--server.port=0"});
         personRepository = context.getBean(PersonRepository.class);
         String port = context.getEnvironment().getProperty("local.server.port");
-        System.setProperty("karate.server.port", port);
+        System.setProperty("example.server.port", port);
+        System.setProperty("karate.env", "mock-e2e");
         Person peter = new Person("Peter", "Pan");
         personRepository.save(peter);        
     }
-    
-    
+     
     @AfterClass
     public static void afterClass() {
         personRepository.deleteAll();

--- a/src/test/java/example/example-api.feature
+++ b/src/test/java/example/example-api.feature
@@ -1,7 +1,7 @@
-Feature: e2e rest
+Feature: controller via mock-servlet
 
 Background:
-    * url 'http://localhost:' + karate.properties['karate.server.port']
+    * url baseUrl
 
 Scenario: should return hello world
     Given path 'hello'
@@ -14,3 +14,9 @@ Scenario: should return greeting
     When method get
     Then status 200
     And match response == 'Hello Peter Pan!'
+
+Scenario: should return current weather
+    Given path 'weather'
+    When method get
+    Then status 200
+    And match response == 'Hamburg, 8°C raining'

--- a/src/test/java/example/hello-e2e-rest.feature
+++ b/src/test/java/example/hello-e2e-rest.feature
@@ -1,0 +1,16 @@
+Feature: e2e rest
+
+Background:
+    * url 'http://localhost:' + karate.properties['karate.server.port']
+
+Scenario: should return hello world
+    Given path 'hello'
+    When method get
+    Then status 200
+    And match response == 'Hello World!'
+
+Scenario: should return greeting
+    Given path 'hello', 'Pan'
+    When method get
+    Then status 200
+    And match response == 'Hello Peter Pan!'

--- a/src/test/java/example/weather/WeatherAcceptanceKarateTest.java
+++ b/src/test/java/example/weather/WeatherAcceptanceKarateTest.java
@@ -1,0 +1,22 @@
+package example.weather;
+
+import com.intuit.karate.junit4.Karate;
+import com.intuit.karate.netty.FeatureServer;
+import cucumber.api.CucumberOptions;
+import java.io.File;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+@RunWith(Karate.class)
+@CucumberOptions(features = "classpath:example/weather/weather.feature")
+public class WeatherAcceptanceKarateTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        File file = new File("src/test/java/example/weather/weather-mock.feature");
+        FeatureServer server = FeatureServer.start(file, 0, false, null);
+        System.setProperty("karate.env", "mock-weather");
+        System.setProperty("weather.server.port", server.getPort() + "");
+    }
+
+}

--- a/src/test/java/example/weather/WeatherClientIntegrationKarateTest.java
+++ b/src/test/java/example/weather/WeatherClientIntegrationKarateTest.java
@@ -1,0 +1,30 @@
+package example.weather;
+
+import com.intuit.karate.netty.FeatureServer;
+import java.io.File;
+import java.util.Optional;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+
+public class WeatherClientIntegrationKarateTest {
+    
+    private static WeatherClient subject;    
+    
+    @BeforeClass
+    public static void beforeClass() {
+        File file = new File("src/test/java/example/weather/weather-mock.feature");
+        FeatureServer server = FeatureServer.start(file, 0, false, null);
+        subject = new WeatherClient(new RestTemplateBuilder().build(), "http://localhost:" + server.getPort(), "some-test-api-key");
+    }    
+    
+    @Test
+    public void shouldCallWeatherService() throws Exception {
+        Optional<WeatherResponse> weatherResponse = subject.fetchWeather();
+        Optional<WeatherResponse> expectedResponse = Optional.of(new WeatherResponse("Rain"));
+        assertThat(weatherResponse, is(expectedResponse));
+    }
+    
+}

--- a/src/test/java/example/weather/weather-mock.feature
+++ b/src/test/java/example/weather/weather-mock.feature
@@ -1,0 +1,4 @@
+Feature: weather mock
+
+Scenario: pathMatches('/{api-key}/{coordinates}')
+    * def response = read('classpath:weatherApiResponse.json')

--- a/src/test/java/example/weather/weather.feature
+++ b/src/test/java/example/weather/weather.feature
@@ -1,0 +1,12 @@
+Feature: weather consumer contract test
+
+Background:
+    * url baseUrl
+
+Scenario: get weather
+    * def coordinates = '53.5511,9.9937'
+    Given path 'some-test-api-key', coordinates
+    When method get
+    Then status 200
+    And match response.currently.summary == 'Rain'
+

--- a/src/test/java/karate-config.js
+++ b/src/test/java/karate-config.js
@@ -1,0 +1,12 @@
+function() {
+  var port = 8080;
+  if (karate.env == 'mock-servlet') {
+    var Mock = Java.type('example.ExampleControllerAPIKarateTest');
+    karate.configure('httpClientInstance', Mock.getMock());
+  } else if (karate.env == 'mock-e2e') {
+    port = karate.properties['example.server.port'];
+  } else if (karate.env == 'mock-weather') {
+    port = karate.properties['weather.server.port'];
+  }
+  return { baseUrl: 'http://localhost:' + port };
+}


### PR DESCRIPTION
Karate unifies HTTP integration testing and mocks and so can replace REST-assured, wiremock, pact and even Spring mock-mvc. The interesting thing about Karate's mock-servlet approach is that it can re-use the exact same HTTP integration (or contract) test script for testing the controller with mocks and without booting the app server.

Can you take a look, see if I missed anything !